### PR TITLE
Correct way to use isOp()

### DIFF
--- a/src/SoyDavs/NickUI/commands/RealNameCommand.php
+++ b/src/SoyDavs/NickUI/commands/RealNameCommand.php
@@ -5,6 +5,7 @@ namespace SoyDavs\NickUI\commands;
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\player\Player;
+use pocketmine\Server;
 use SoyDavs\NickUI\Main;
 
 class RealNameCommand extends Command {
@@ -37,7 +38,7 @@ class RealNameCommand extends Command {
 
         // Check if sender is a Player and has OP permissions
         if ($sender instanceof Player) {
-            if (!$sender->hasPermission("pocketmine.permission.op")) {
+            if (!Server::getInstance()->isOp($sender->getName())) {
                 $sender->sendMessage("§cYou do not have permission to use this command.");
                 return true;
             }


### PR DESCRIPTION
ChatGPT doesn’t know that the method “isOp()” got moved to Server::class and so it tried to use “$sender->isOp()”. The correct way is:

$player being an instance of Player class

$name = $player->getName();

Server::getInstance()->isOp($name);

I suggest looking into the API more than trusting ChatGPT lol

also this method isn’t necessarily needed since “$this->testPermisson($sender)” does it for you assuming you have the permission set to “op” rather than “true”.